### PR TITLE
feat: formance class name and maxMethodParams

### DIFF
--- a/gen.yaml
+++ b/gen.yaml
@@ -1,10 +1,10 @@
 configVersion: 1.0.0
 generation:
-  sdkClassName: SDK
+  sdkClassName: formance
   singleTagPerOp: true
   telemetryEnabled: false
 typescript:
   version: v1.0.20230623-beta.1
   author: Formance
-  maxMethodParams: 0
+  maxMethodParams: 4
   packageName: '@formance/formance-sdk'


### PR DESCRIPTION
Summary of changes: 
- changing to `formance` class name so the usage is `const sdk = new formance({ ...`
- setting `maxMethodParams` to be used inline before creating request objects